### PR TITLE
Remove experimental cluster knowledge

### DIFF
--- a/aws_bucket_access/README.md
+++ b/aws_bucket_access/README.md
@@ -107,8 +107,3 @@ output "access_key" {
   sensitive = true
 }
 ```
-
-
-
-
-

--- a/aws_bucket_access/role.tf
+++ b/aws_bucket_access/role.tf
@@ -5,23 +5,23 @@ data "aws_iam_policy_document" "vault_auth" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${local.caller_account_id}:user/sys-vault-${var.exp_cluster ? "exp-1-" : ""}credentials-provider",
-        "arn:aws:iam::${local.caller_account_id}:user/sys-vault-${var.exp_cluster ? "exp-1-" : ""}credentials-provider-gcp",
-        "arn:aws:iam::${local.caller_account_id}:user/sys-vault-${var.exp_cluster ? "exp-1-" : ""}credentials-provider-merit",
+        "arn:aws:iam::${local.caller_account_id}:user/sys-vault-credentials-provider",
+        "arn:aws:iam::${local.caller_account_id}:user/sys-vault-credentials-provider-gcp",
+        "arn:aws:iam::${local.caller_account_id}:user/sys-vault-credentials-provider-merit",
       ]
     }
   }
 }
 
 resource "aws_iam_role" "role" {
-  count                = var.access_method == "vault_role" ? 1 : 0
+  count                = var.access_method == "iam_role" ? 1 : 0
   name                 = "${local.caller_team}-${local.bucket_name_without_prefixes}-bucket-${var.write_access ? "rw" : "ro"}"
-  assume_role_policy   = data.aws_iam_policy_document.vault_auth.json
+  assume_role_policy   = var.iam_role_auth_policy != "" ? var.iam_role_auth_policy : data.aws_iam_policy_document.vault_auth.json
   permissions_boundary = "arn:aws:iam::${local.caller_account_id}:policy/sys-${local.caller_team}-boundary"
 }
 
 resource "aws_iam_role_policy" "role" {
-  count  = var.access_method == "vault_role" ? 1 : 0
+  count  = var.access_method == "iam_role" ? 1 : 0
   name   = "${local.caller_team}-${local.bucket_name_without_prefixes}-bucket-${var.write_access ? "rw" : "ro"}"
   role   = aws_iam_role.role[0].id
   policy = var.write_access ? data.aws_iam_policy_document.rw.json : data.aws_iam_policy_document.ro.json

--- a/aws_bucket_access/variables.tf
+++ b/aws_bucket_access/variables.tf
@@ -2,19 +2,19 @@ variable "bucket_id" {
   description = "Id of the bucket to be accessed"
 
   validation {
-    condition = substr(var.bucket_id, 0, 3) == "uw-"
+    condition     = substr(var.bucket_id, 0, 3) == "uw-"
     error_message = "The bucket_id must follow the format 'uw-<environment>-<team>-*'."
   }
 }
 
 variable "access_method" {
   type        = string
-  description = "Type of bucket access. Can be 'vault_role' or 'iam_user'."
-  default     = "vault_role"
+  description = "Type of bucket access. Can be 'iam_role' or 'iam_user'."
+  default     = "iam_role"
 
   validation {
-    condition     = contains(["vault_role", "iam_user"], var.access_method)
-    error_message = "The access_type must be one of: vault_role, iam_user."
+    condition     = contains(["iam_role", "iam_user"], var.access_method)
+    error_message = "The access_type must be one of: iam_role, iam_user."
   }
 }
 
@@ -24,14 +24,14 @@ variable "write_access" {
   default     = false
 }
 
-variable "exp_cluster" {
-  description = "Is the bucket to be accessed from an experimental cluster?"
-  type        = bool
-  default     = false
+variable "iam_role_auth_policy" {
+  description = "Auth policy for the iam_role. If left blank, only vault would be able to assume the role"
+  type        = string
+  default     = ""
 }
 
 locals {
   bucket_name_without_uw       = trimprefix(var.bucket_id, "uw-")
-  bucket_name_without_env     = trimprefix(local.bucket_name_without_uw, local.caller_account_alias)
+  bucket_name_without_env      = trimprefix(local.bucket_name_without_uw, local.caller_account_alias)
   bucket_name_without_prefixes = trimprefix(local.bucket_name_without_env, "-${local.caller_team}-")
 }


### PR DESCRIPTION
Instead of accepting a bool to detect an exp cluster, take a complete
auth policy as input. This way the module is not aware of exp clusters
and it's more flexible, since it allows customized auth for roles.