### PR TITLE
[DENA-490] additional permissions for bucket access role

### DIFF
--- a/aws_bucket_access/policies.tf
+++ b/aws_bucket_access/policies.tf
@@ -2,7 +2,11 @@ data "aws_iam_policy_document" "ro" {
   statement {
     actions = [
       "s3:ListBucket",
+      "s3:GetBucketLocation",
+      "s3:ListBucketMultipartUploads",
+      "s3:ListBucketVersions",
       "s3:GetObject",
+      "s3:ListMultipartUploadParts",
     ]
     resources = [
       "arn:aws:s3:::${var.bucket_id}",
@@ -15,9 +19,14 @@ data "aws_iam_policy_document" "rw" {
   statement {
     actions = [
       "s3:ListBucket",
+      "s3:GetBucketLocation",
+      "s3:ListBucketMultipartUploads",
+      "s3:ListBucketVersions",
       "s3:GetObject",
       "s3:PutObject",
       "s3:DeleteObject",
+      "s3:AbortMultipartUpload",
+      "s3:ListMultipartUploadParts",
     ]
     resources = [
       "arn:aws:s3:::${var.bucket_id}",


### PR DESCRIPTION
This PR adds to bucket policies [permissions necessary to create ElasticSearch backups](https://www.elastic.co/guide/en/elasticsearch/reference/current/repository-s3.html#repository-s3-permissions).

I allowed myself to propose them in main bucket policy, because the new policies doesn't seem harmful. 
However, if adding them is not advised, I could maybe create new directory with advanced bucket access. 

I think we need it, as almost every namespace now contains some elasticsearch, many of them are backed up to some bucket, and I'm preparing documentation how to back up [shared-manifest elasticsearch](https://github.com/utilitywarehouse/shared-kustomize-bases/tree/main/elasticsearch)