### PR TITLE
DENA 1340 - add tf module for setting up the IAM role used in a backup plan

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @utilitywarehouse/system

--- a/rds_backup_plan_role/README.md
+++ b/rds_backup_plan_role/README.md
@@ -1,0 +1,24 @@
+# RDS backup plan role Terraform module
+
+This module sets up the AWS IAM role to be used in the [backup plan](https://docs.aws.amazon.com/aws-backup/latest/devguide/about-backup-plans.html) for an RDS instance.
+
+## Usage
+
+```terraform
+# declare the role
+module "rds_backup_plan_role" {
+  source   = "github.com/utilitywarehouse/system-terraform-modules//rds_backup_plan_role?ref=d044000e7f1164abb48d984035e8dc8b43e13434"
+  rds_name = local.rds_name
+}
+
+# use the role in a backup plan selection
+resource "aws_backup_selection" "rds_backup_selection" {
+  name         = "${local.rds_name}-backup-selection"
+  plan_id      = aws_backup_plan.rds_backup_plan.id
+  iam_role_arn = module.rds_backup_plan_role.role.arn
+
+  resources = [
+    aws_db_instance.postgres.arn
+  ]
+}
+```

--- a/rds_backup_plan_role/caller.tf
+++ b/rds_backup_plan_role/caller.tf
@@ -1,0 +1,10 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  uw_account_aliases_map = {
+    950135041896 = "dev"
+    703452047160 = "prod"
+  }
+  caller_account_id    = data.aws_caller_identity.current.account_id
+  caller_team          = trimsuffix(split("/", data.aws_caller_identity.current.arn)[1], "-admin")
+}

--- a/rds_backup_plan_role/caller.tf
+++ b/rds_backup_plan_role/caller.tf
@@ -1,10 +1,6 @@
 data "aws_caller_identity" "current" {}
 
 locals {
-  uw_account_aliases_map = {
-    950135041896 = "dev"
-    703452047160 = "prod"
-  }
   caller_account_id    = data.aws_caller_identity.current.account_id
   caller_team          = trimsuffix(split("/", data.aws_caller_identity.current.arn)[1], "-admin")
 }

--- a/rds_backup_plan_role/role.tf
+++ b/rds_backup_plan_role/role.tf
@@ -129,3 +129,10 @@ resource "aws_iam_role_policy" "backup_policy_attachment" {
   role   = aws_iam_role.backup_role.name
   policy = data.aws_iam_policy_document.backup_policy.json
 }
+
+output "role" {
+  value = {
+    name = aws_iam_role.backup_role.name
+    arn  = aws_iam_role.backup_role.arn
+  }
+}

--- a/rds_backup_plan_role/role.tf
+++ b/rds_backup_plan_role/role.tf
@@ -1,0 +1,131 @@
+data "aws_iam_policy_document" "backup_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["backup.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "backup_role" {
+  name               = "${var.rds_name}-backup-role"
+  permissions_boundary = "arn:aws:iam::${local.caller_account_id}:policy/sys-${local.caller_team}-boundary"
+  assume_role_policy = data.aws_iam_policy_document.backup_assume_role.json
+}
+
+data "aws_iam_policy_document" "backup_policy" {
+  # build from https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSBackupServiceRolePolicyForBackup.html
+  statement {
+    effect = "Allow"
+    actions = [
+      "rds:DescribeDBInstances",
+      "rds:CreateDBSnapshot",
+      "rds:DeleteDBSnapshot",
+      "rds:ModifyDBSnapshotAttribute",
+      "rds:DescribeDBSnapshots",
+      "rds:ListTagsForResource",
+      "rds:ModifyDBInstance",
+      "rds:DeleteDBInstanceAutomatedBackup",
+      "rds:ModifyDBCluster",
+      "rds:DeleteDBClusterAutomatedBackup"
+    ]
+    resources = [
+      "arn:aws:rds:*:*:*:${local.caller_team}-*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "rds:CreateDBSnapshot",
+      "rds:AddTagsToResource"
+    ]
+    resources = [
+      "arn:aws:rds:*:*:snapshot:awsbackup:*",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/owner"
+      values = [
+        local.caller_team
+      ]
+    }
+
+  }
+
+  # needs describes on all to create snapshots
+  statement {
+    effect = "Allow"
+    actions = [
+      "rds:DescribeDBSnapshots",
+    ]
+    resources = [
+      "arn:aws:rds:*:*:snapshot:awsbackup:*",
+    ]
+  }
+
+  statement {
+    # full team backup access
+    actions = [
+      "backup:StartBackupJob",
+      "backup:StopBackupJob",
+      "backup:ListBackupJobs",
+      "backup:ListBackupPlans",
+      "backup:ListBackupVaults",
+      "backup:GetBackupPlan",
+      "backup:GetBackupVaultAccessPolicy",
+      "backup:GetBackupVaultNotifications",
+      "backup:PutBackupVaultAccessPolicy",
+      "backup:PutBackupVaultNotifications",
+      "backup:DescribeBackupVault",
+      "backup:CopyIntoBackupVault",
+      "backup:CopyFromBackupVault"
+    ]
+
+    resources = [
+      "arn:aws:backup:*:*:*:${local.caller_team}-*",
+    ]
+  }
+
+  statement {
+    sid    = "KmsPermissions"
+    effect = "Allow"
+    actions = [
+      "kms:List*",
+      "kms:Describe*",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "KMSCreateGrantPermissions"
+    effect = "Allow"
+    actions = [
+      "kms:CreateGrant"
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "Bool"
+      variable = "kms:GrantIsForAWSResource"
+      values   = ["true"]
+    }
+  }
+
+  statement {
+    sid       = "GetResourcesPermissions"
+    effect    = "Allow"
+    actions   = ["tag:GetResources"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "backup_policy_attachment" {
+  name   = "${var.rds_name}-backup-role-policy"
+  role   = aws_iam_role.backup_role.name
+  policy = data.aws_iam_policy_document.backup_policy.json
+}

--- a/rds_backup_plan_role/variables.tf
+++ b/rds_backup_plan_role/variables.tf
@@ -1,0 +1,3 @@
+variable "rds_name" {
+  description = "The name of the RDS instance"
+}


### PR DESCRIPTION
AWS backup should be used for retaining RDS backups more than 35 days.