### PR TITLE
DENA 1412 move rds user

### DIFF
--- a/rds_user/README.md
+++ b/rds_user/README.md
@@ -11,7 +11,7 @@ Consult [iam.tf](iam.tf) and [postgres.tf](postgres.tf) to see what resources it
 ```terraform
 # Example for user with read and write permissions
 module "rw-user" {
-  source      = "github.com/utilitywarehouse/system-terraform-modules//rds_user?ref=f59eaabd6aefe0e27b9a7fa8d254eef7e05bf202"
+  source      = "github.com/utilitywarehouse/system-terraform-modules//rds_user?ref=029ffb430d29d6f900b6839ad4997e932d9069bb"
   name        = "rw-user"
   database    = postgresql_database.my_db.name
   privilege   = "read/write"
@@ -20,7 +20,7 @@ module "rw-user" {
 
 # Example for user with read-only permissions
 module "ro-user" {
-  source      = "github.com/utilitywarehouse/system-terraform-modules//rds_user?ref=f59eaabd6aefe0e27b9a7fa8d254eef7e05bf202"
+  source      = "github.com/utilitywarehouse/system-terraform-modules//rds_user?ref=029ffb430d29d6f900b6839ad4997e932d9069bb"
   name        = "ro-user"
   database    = postgresql_database.my_db.name
   privilege   = "read"

--- a/rds_user/README.md
+++ b/rds_user/README.md
@@ -1,0 +1,40 @@
+# RDS user Terraform module
+
+This module sets up the AWS IAM & AWS RDS instance to allow a user to connect to an RDS postgres DB.
+
+See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html.
+
+Consult [iam.tf](iam.tf) and [postgres.tf](postgres.tf) to see what resources it defines and [variables.tf](variables.tf) for available input variables.
+
+## Usage example:
+
+```terraform
+# Example for user with read and write permissions
+module "rw-user" {
+  source      = "github.com/utilitywarehouse/system-terraform-modules//rds_user?ref=f59eaabd6aefe0e27b9a7fa8d254eef7e05bf202"
+  name        = "rw-user"
+  database    = postgresql_database.my_db.name
+  privilege   = "read/write"
+  db_instance = aws_db_instance.postgres
+}
+
+# Example for user with read-only permissions
+module "ro-user" {
+  source      = "github.com/utilitywarehouse/system-terraform-modules//rds_user?ref=f59eaabd6aefe0e27b9a7fa8d254eef7e05bf202"
+  name        = "ro-user"
+  database    = postgresql_database.my_db.name
+  privilege   = "read"
+  db_instance = aws_db_instance.postgres
+}
+
+# Example for using an already existing IAM role used for accessing an S3 bucket: 
+module "sample_db_existing_role" {
+  source      = "github.com/utilitywarehouse/system-terraform-modules//rds_user?ref=b07882f5fd16608af060ba589bf9f4db578a411a"
+  name        = "sample-db-existing-role"
+  database    = postgresql_database.sample_db.name
+  privilege   = "read/write"
+  db_instance = aws_db_instance.postgres
+  existing_iam_role = "dev-enablement-test-backups-bucket-rw"
+}
+
+```

--- a/rds_user/caller.tf
+++ b/rds_user/caller.tf
@@ -1,0 +1,7 @@
+# Based on https://github.com/utilitywarehouse/system-terraform-modules/blob/main/aws_bucket_access/caller.tf
+data "aws_caller_identity" "current" {}
+
+locals {
+  caller_account_id = data.aws_caller_identity.current.account_id
+  caller_team       = trimsuffix(split("/", data.aws_caller_identity.current.arn)[1], "-admin")
+}

--- a/rds_user/iam.tf
+++ b/rds_user/iam.tf
@@ -1,0 +1,55 @@
+locals {
+  # arn looks like arn:aws:rds:eu-west-1:950135041896:db:dev-enablement-rds
+  region = split(":", var.db_instance.arn)[3]
+  default_iam_role_name = "${var.db_instance.identifier}-${var.name}"
+}
+
+# Creates an IAM role that can be assumed through Vault that has the privilege to connect to the RDS instance.
+data "aws_iam_policy_document" "vault_auth" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${local.caller_account_id}:user/sys-vault-credentials-provider",
+        "arn:aws:iam::${local.caller_account_id}:user/sys-vault-credentials-provider-gcp",
+        "arn:aws:iam::${local.caller_account_id}:user/sys-vault-credentials-provider-merit",
+      ]
+    }
+  }
+}
+
+/*  do not create another role if an existing one was passed in. */
+resource "aws_iam_role" "iam_access_role" {
+  count = var.existing_iam_role == null ? 1 : 0
+  name                 = local.default_iam_role_name
+  assume_role_policy   = data.aws_iam_policy_document.vault_auth.json
+  permissions_boundary = "arn:aws:iam::${local.caller_account_id}:policy/sys-${local.caller_team}-boundary"
+}
+
+
+resource "aws_iam_role_policy" "access_role_policy" {
+  name   = "${var.db_instance.identifier}-${var.name}"
+  role   = var.existing_iam_role == null ? local.default_iam_role_name : var.existing_iam_role
+  policy = data.aws_iam_policy_document.rds_policy_doc.json
+}
+
+data "aws_iam_policy_document" "rds_policy_doc" {
+  statement {
+    actions = [
+      "rds-db:connect",
+    ]
+
+    resources = [
+      "arn:aws:rds-db:${local.region}:${local.caller_account_id}:dbuser:${var.db_instance.id}/${var.name}"
+    ]
+  }
+}
+
+output "iam_access_role" {
+  value = {
+    name = var.existing_iam_role == null ? aws_iam_role.iam_access_role[0].name : var.existing_iam_role
+    arn  = var.existing_iam_role == null ? aws_iam_role.iam_access_role[0].arn : "use the arn of the existing role"
+  }
+}

--- a/rds_user/postgres.tf
+++ b/rds_user/postgres.tf
@@ -1,0 +1,44 @@
+terraform {
+  required_providers {
+    postgresql = {
+      source  = "cyrilgdn/postgresql"
+      version = ">= 1.24.0"
+    }
+  }
+}
+
+# Creates the role in postgres with the appropriate privileges.
+resource "postgresql_role" "pg_access_role" {
+  name     = var.name
+  login    = true
+  password = "NULL"
+  # Allows access for this role through IAM authentication.
+  # See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.DBAccounts.html
+  roles = ["rds_iam"]
+}
+
+resource "postgresql_grant" "db_grant" {
+  database    = var.database
+  role        = var.name
+  object_type = "database"
+  privileges  = var.privilege == "read" ? ["CONNECT"] : ["CONNECT", "CREATE", "TEMPORARY"]
+  depends_on  = [postgresql_role.pg_access_role]
+}
+
+resource "postgresql_grant" "schema_grant" {
+  database    = var.database
+  role        = var.name
+  object_type = "schema"
+  schema      = "public"
+  privileges  = var.privilege == "read" ? ["USAGE"] : ["CREATE", "USAGE"]
+  depends_on  = [postgresql_role.pg_access_role]
+}
+
+resource "postgresql_grant" "table_grant" {
+  database    = var.database
+  role        = var.name
+  object_type = "table"
+  schema      = "public"
+  privileges  = var.privilege == "read" ? ["SELECT"] : ["DELETE", "INSERT", "REFERENCES", "SELECT", "TRIGGER", "TRUNCATE", "UPDATE"]
+  depends_on  = [postgresql_role.pg_access_role]
+}

--- a/rds_user/variables.tf
+++ b/rds_user/variables.tf
@@ -1,0 +1,32 @@
+variable "name" {
+  description = "Name of the user"
+}
+
+variable "database" {
+  description = "Database the user gets access to"
+}
+
+variable "existing_iam_role" {
+  type = string
+  description = "The IAM role name to grant privileges to. This allows using an already existing role that is used with vault, and it will add to its privileges. For example enables an app to connect both to S3 and to RDS using a single role"
+  nullable = true
+  default = null
+}
+
+variable "privilege" {
+  description = "Type of privilege to grant user on the specified database"
+  validation {
+    condition     = contains(["read", "read/write"], var.privilege)
+    error_message = "Privilege must be \"read\" or \"read/write\""
+  }
+  default = "read"
+}
+
+variable "db_instance" {
+  description = "The aws_db_instance for which the user is defined"
+  type = object({
+    id         = string
+    arn        = string
+    identifier = string
+  })
+}


### PR DESCRIPTION
Move rds_user module under system-terraform-modules.

This is copied from https://github.com/utilitywarehouse/dev-enablement-mono/tree/main/tf-modules/rds_user and the examples were addapted
