### PR TITLE
Specify a filter per rule and retention days on IT

### DIFF
--- a/aws_bucket/bucket.tf
+++ b/aws_bucket/bucket.tf
@@ -67,7 +67,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "lifecycle" {
     content {
       id     = "object-expiration"
       status = "Enabled"
-
+      filter {}
       expiration {
         days = var.object_expiration_days
       }
@@ -80,7 +80,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "lifecycle" {
     content {
       id     = "version-expiration"
       status = "Enabled"
-
+      filter {}
       noncurrent_version_expiration {
         noncurrent_days = var.version_expiration_days
       }
@@ -94,7 +94,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "lifecycle" {
     content {
       id     = "default-to-intelligent-tiering"
       status = "Enabled"
+      filter {}
       transition {
+        days          = 0
         storage_class = "INTELLIGENT_TIERING"
       }
     }


### PR DESCRIPTION
Starting with v5.90.0 `aws_s3_bucket_lifecycle_configuration` requires
`days` in `transition` block, even for intelligent teiring.

As well as a single `filter` per `rule` blocks. Empty filter means "all
objects", so same logic as omitting it.

https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.90.0
