### PR TITLE
rds-user: added option to include no privileges so that teams can define their own granular ones

### DIFF
--- a/rds_user/README.md
+++ b/rds_user/README.md
@@ -31,7 +31,7 @@ module "ro-user" {
 
 # Example for user with no permissions and then defining custom grants
 module "custom-grants-user" {
-  source      = "git@github.com:utilitywarehouse/system-terraform-modules//rds_user?ref=1c1b91c66e166404f305a26aca2f8236fd47ee99"
+  source      = "git@github.com:utilitywarehouse/system-terraform-modules//rds_user?ref=5aaa8d1dba8b45023ef6e576db298fb3d5e7bdd9"
   team        = "finance"
   name        = "custom-grants"
   database    = postgresql_database.my_db.name
@@ -40,12 +40,11 @@ module "custom-grants-user" {
 }
 
 resource "postgresql_grant" "db_grant" {
-  count       = var.privilege == "none" ? 0 : 1
   database    = postgresql_database.my_db.name
   role        = "custom-grants"
   object_type = "database"
   privileges  = ["CONNECT", "CREATE"]
-  depends_on  = module.custom-grants-user.postgresql_role
+  depends_on  = [module.custom-grants-user.postgresql_role]
 }
 
 

--- a/rds_user/README.md
+++ b/rds_user/README.md
@@ -29,6 +29,26 @@ module "ro-user" {
   db_instance = aws_db_instance.postgres
 }
 
+# Example for user with no permissions and then defining custom grants
+module "custom-grants-user" {
+  source      = "git@github.com:utilitywarehouse/system-terraform-modules//rds_user?ref=1c1b91c66e166404f305a26aca2f8236fd47ee99"
+  team        = "finance"
+  name        = "custom-grants"
+  database    = postgresql_database.my_db.name
+  privilege   = "none"
+  db_instance = aws_db_instance.postgres
+}
+
+resource "postgresql_grant" "db_grant" {
+  count       = var.privilege == "none" ? 0 : 1
+  database    = postgresql_database.my_db.name
+  role        = "custom-grants"
+  object_type = "database"
+  privileges  = ["CONNECT", "CREATE"]
+  depends_on  = module.custom-grants-user.postgresql_role
+}
+
+
 # Example for using an already existing IAM role used for accessing an S3 bucket:
 module "sample_db_existing_role" {
   source      = "git@github.com:utilitywarehouse/system-terraform-modules//rds_user?ref=1c1b91c66e166404f305a26aca2f8236fd47ee99"

--- a/rds_user/postgres.tf
+++ b/rds_user/postgres.tf
@@ -17,7 +17,15 @@ resource "postgresql_role" "pg_access_role" {
   roles = ["rds_iam"]
 }
 
+output "postgresql_role" {
+  description = "The postgresql_role resource created"
+  value       = postgresql_role.pg_access_role
+}
+
+# grants are included when the privilege variable is different than "none"
+
 resource "postgresql_grant" "db_grant" {
+  count       = var.privilege == "none" ? 0 : 1
   database    = var.database
   role        = var.name
   object_type = "database"
@@ -26,6 +34,7 @@ resource "postgresql_grant" "db_grant" {
 }
 
 resource "postgresql_grant" "schema_grant" {
+  count       = var.privilege == "none" ? 0 : 1
   database    = var.database
   role        = var.name
   object_type = "schema"
@@ -35,6 +44,7 @@ resource "postgresql_grant" "schema_grant" {
 }
 
 resource "postgresql_grant" "table_grant" {
+  count       = var.privilege == "none" ? 0 : 1
   database    = var.database
   role        = var.name
   object_type = "table"
@@ -44,6 +54,7 @@ resource "postgresql_grant" "table_grant" {
 }
 
 resource "postgresql_grant" "sequence_grant" {
+  count       = var.privilege == "none" ? 0 : 1
   database    = var.database
   role        = var.name
   object_type = "sequence"

--- a/rds_user/variables.tf
+++ b/rds_user/variables.tf
@@ -20,8 +20,8 @@ variable "existing_iam_role" {
 variable "privilege" {
   description = "Type of privilege to grant user on the specified database"
   validation {
-    condition     = contains(["read", "read/write"], var.privilege)
-    error_message = "Privilege must be \"read\" or \"read/write\""
+    condition     = contains(["read", "read/write", "none"], var.privilege)
+    error_message = "Privilege must be one of 'read','read/write' or 'none'"
   }
   default = "read"
 }


### PR DESCRIPTION
This came from this thread https://utilitywarehouse.slack.com/archives/C37EHB3R6/p1757337636246199 , but it was also an older request from energy where they have more granular permissions.

I tested it already on the sys-example-rds roles