### PR TITLE
Ensure rds_user role policy waits for role creation

### DIFF
--- a/rds_user/iam.tf
+++ b/rds_user/iam.tf
@@ -31,7 +31,7 @@ resource "aws_iam_role" "iam_access_role" {
 
 resource "aws_iam_role_policy" "access_role_policy" {
   name   = "${var.db_instance.identifier}-${var.name}"
-  role   = var.existing_iam_role == null ? local.default_iam_role_name : var.existing_iam_role
+  role   = var.existing_iam_role == null ? aws_iam_role.iam_access_role[0].id : var.existing_iam_role
   policy = data.aws_iam_policy_document.rds_policy_doc.json
 }
 


### PR DESCRIPTION
The inline IAM role policy currently references the role by its computed
name, so Terraform does not infer a dependency on the aws_iam_role resource.

Reference the created role resource instead, so PutRolePolicy is not attempted
before the role and its permissions boundary have finished being created.
